### PR TITLE
Add generic probes

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -3,7 +3,7 @@ name: generic
 description: A generic Helm chart for Kubernetes
 
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: latest
 maintainers:
   - name: colearendt

--- a/charts/generic/NEWS.md
+++ b/charts/generic/NEWS.md
@@ -1,3 +1,9 @@
+# 0.1.5
+
+- Add values for `readinessProbe`, `livenessProbe` and `startupProbe`
+  - This allows customization of probes
+  - Previously, `readinessProbe` was hardcoded
+
 # 0.1.4
 
 - Add `extraObjects` for arbitrary deployment possibilities!

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A generic Helm chart for Kubernetes
 
@@ -30,12 +30,15 @@ A generic Helm chart for Kubernetes
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
+| livenessProbe | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | pod.env | list | `[]` |  |
 | pod.port | int | `80` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| readinessProbe.httpGet.path | string | `"/"` |  |
+| readinessProbe.httpGet.port | string | `"http"` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
@@ -44,6 +47,7 @@ A generic Helm chart for Kubernetes
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. -- If not set and create is true, a name is generated using the fullname template |
+| startupProbe | object | `{}` |  |
 | storage.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storage.create | bool | `false` |  |
 | storage.name | string | `""` |  |

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -30,15 +30,14 @@ A generic Helm chart for Kubernetes
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
-| livenessProbe | object | `{}` |  |
+| livenessProbe | object | `{}` | customize the primary container's livenessProbe. Default none |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | pod.env | list | `[]` |  |
 | pod.port | int | `80` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| readinessProbe.httpGet.path | string | `"/"` |  |
-| readinessProbe.httpGet.port | string | `"http"` |  |
+| readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | customize the primary container's readinessProbe. Default is httpGet on the default `http` port |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
@@ -47,7 +46,7 @@ A generic Helm chart for Kubernetes
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. -- If not set and create is true, a name is generated using the fullname template |
-| startupProbe | object | `{}` |  |
+| startupProbe | object | `{}` | customize the primary container's startupProbe. Default none |
 | storage.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | storage.create | bool | `false` |  |
 | storage.name | string | `""` |  |

--- a/charts/generic/ci/all-values.yaml
+++ b/charts/generic/ci/all-values.yaml
@@ -94,3 +94,13 @@ extraObjects:
       name: "templating"
     data:
       something: {{ printf "special" }}
+
+readinessProbe: null
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+startupProbe:
+  httpGet:
+    path: /
+    port: http

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -39,10 +39,18 @@ spec:
             - name: http
               containerPort: {{ .Values.pod.port }}
               protocol: TCP
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12}}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -90,10 +90,13 @@ affinity: {}
 # -- Extra kubernetes objects to deploy (value evaluted as a template)
 extraObjects: []
 
+# -- customize the primary container's readinessProbe. Default is httpGet on the default `http` port
 readinessProbe:
   httpGet:
     path: /
     port: http
 
+# -- customize the primary container's livenessProbe. Default none
 livenessProbe: {}
+# -- customize the primary container's startupProbe. Default none
 startupProbe: {}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -89,3 +89,11 @@ affinity: {}
 
 # -- Extra kubernetes objects to deploy (value evaluted as a template)
 extraObjects: []
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+livenessProbe: {}
+startupProbe: {}


### PR DESCRIPTION
Allow customizing probes for the generic chart
(leave defaults intact for backwards compat). The default is pretty nice for the most part, anyways.