### PR TITLE
Add ingress for traefik-forward-auth

### DIFF
--- a/charts/traefik-forward-auth/Chart.yaml
+++ b/charts/traefik-forward-auth/Chart.yaml
@@ -1,6 +1,6 @@
 name: traefik-forward-auth
 description: Deploy traefik-forward-auth
-version: 0.0.7
+version: 0.0.8
 apiVersion: v1
 sources:
   - https://github.com/thomseddon/traefik-forward-auth

--- a/charts/traefik-forward-auth/NEWS.md
+++ b/charts/traefik-forward-auth/NEWS.md
@@ -1,3 +1,7 @@
+# 0.0.8
+
+- Add `ingress` values to more easily deploy an ingress object
+
 # 0.0.7
 
 - Add `extraObjects` value for deploying other kubernetes objects.

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -1,14 +1,14 @@
 # traefik-forward-auth
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square)
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.0.7:
+To install the chart with the release name `my-release` at version 0.0.8:
 
 ```bash
 helm repo add colearendt https://colearendt.github.io/helm
-helm install my-release colearendt/traefik-forward-auth --version=0.0.7
+helm install my-release colearendt/traefik-forward-auth --version=0.0.8
 ```
 
 #### _Deploy traefik-forward-auth_
@@ -23,15 +23,23 @@ helm install my-release colearendt/traefik-forward-auth --version=0.0.7
 | config.insecure-cookie | bool | `false` |  |
 | config.log-level | string | `"warn"` |  |
 | extraObjects | list | `[]` | Extra kubernetes objects to deploy (value evaluted as a template) |
+| fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"thomseddon/traefik-forward-auth"` |  |
 | image.tag | int | `2` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.tls | list | `[]` |  |
 | livenessProbe | object | `{}` |  |
+| nameOverride | string | `""` |  |
 | pod.env | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | readinessProbe | object | `{}` |  |
 | replicas | int | `1` |  |
 | resources | object | `{}` |  |
+| service.port | int | `80` |  |
 | serviceAnnotations | object | `{}` |  |
 | startupProbe | object | `{}` |  |
 | strategy | object | `{}` |  |

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -30,7 +30,7 @@ helm install my-release colearendt/traefik-forward-auth --version=0.0.8
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.hosts[0].paths[0] | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | livenessProbe | object | `{}` |  |
 | nameOverride | string | `""` |  |

--- a/charts/traefik-forward-auth/ci/all-values.yaml
+++ b/charts/traefik-forward-auth/ci/all-values.yaml
@@ -31,6 +31,20 @@ livenessProbe: {}
 startupProbe: {}
 readinessProbe: {}
 
+ingress:
+  enabled: true
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: [/]
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+
 extraObjects:
   - apiVersion: v1
     kind: ConfigMap
@@ -45,3 +59,4 @@ extraObjects:
       name: "test2"
     data:
       something: {{ printf "fun2" }}
+      something-else: {{ $.Release.Name | toYaml | nindent 4 }}

--- a/charts/traefik-forward-auth/templates/_helpers.tpl
+++ b/charts/traefik-forward-auth/templates/_helpers.tpl
@@ -1,3 +1,30 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "traefik-forward-auth.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "traefik-forward-auth.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
 {{- define "traefik-forward-auth.annotations" -}}
 {{- range $key,$value := $.Values.serviceAnnotations -}}
 {{ $key }}: {{ $value | quote }}

--- a/charts/traefik-forward-auth/templates/ingress.yaml
+++ b/charts/traefik-forward-auth/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled -}}
+{{- /* $fullName := include "traefik-forward-auth.fullname" . */ -}}
+{{- $fullName := $.Release.Name -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- /* include "traefik-forward-auth.labels" . | nindent 4 */ -}}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/traefik-forward-auth/templates/svc.yaml
+++ b/charts/traefik-forward-auth/templates/svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-  annotations: 
+  annotations:
 {{ include "traefik-forward-auth.annotations" . | indent 4 }}
 spec:
   type: NodePort
@@ -12,6 +12,6 @@ spec:
     app: {{ .Release.Name }}
   ports:
   - protocol: TCP
-    port: 80
+    port: {{ .Values.service.port }}
     targetPort: 4181
 ---

--- a/charts/traefik-forward-auth/values.yaml
+++ b/charts/traefik-forward-auth/values.yaml
@@ -8,6 +8,12 @@ replicas: 1
 podAnnotations: {}
 serviceAnnotations: {}
 
+service:
+  port: 80
+
+nameOverride: ""
+fullnameOverride: ""
+
 image:
   repository: thomseddon/traefik-forward-auth
   tag: 2
@@ -26,3 +32,16 @@ resources: {}
 livenessProbe: {}
 startupProbe: {}
 readinessProbe: {}
+
+ingress:
+  enabled: false
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: [/]
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local


### PR DESCRIPTION
modify deployment a smidge from postgrest because we have not yet switched to the "more sophisticated" naming convention for the service using _helpers.tpl (potentially a problem for longer names)