### PR TITLE
Ingress

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -3,7 +3,7 @@ name: generic
 description: A generic Helm chart for Kubernetes
 
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: latest
 maintainers:
   - name: colearendt

--- a/charts/generic/NEWS.md
+++ b/charts/generic/NEWS.md
@@ -1,3 +1,7 @@
+# 0.2.3
+
+- Update ingress to use newer template, api version, etc.
+
 # 0.2.2
 
 - Update maintainer

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,14 +1,14 @@
 # generic
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.2.2:
+To install the chart with the release name `my-release` at version 0.2.3:
 
 ```bash
 helm repo add colearendt https://colearendt.github.io/helm
-helm install my-release colearendt/generic --version=0.2.2
+helm install my-release colearendt/generic --version=0.2.3
 ```
 
 #### _A generic Helm chart for Kubernetes_
@@ -31,9 +31,11 @@ helm install my-release colearendt/generic --version=0.2.2
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | livenessProbe | object | `{}` | customize the primary container's livenessProbe. Default none |
 | nameOverride | string | `""` |  |

--- a/charts/generic/ci/all-values.yaml
+++ b/charts/generic/ci/all-values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ubuntu
+  repository: nginx
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -23,11 +23,8 @@ pod:
   securityContext: {}
     # fsGroup: 2000
 
-command:
-  - "sh"
-  - "-c"
-args:
-  - "'echo hi'"
+command: []
+args: []
 
 serviceAccount:
   # -- Specifies whether a service account should be created
@@ -104,10 +101,7 @@ extraObjects:
       something: {{ printf "special" }}
 
 readinessProbe: null
-livenessProbe:
-  httpGet:
-    path: /
-    port: http
+livenessProbe: null
 startupProbe:
   httpGet:
     path: /

--- a/charts/generic/ci/all-values.yaml
+++ b/charts/generic/ci/all-values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: nginx
+  repository: ubuntu
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/generic/ci/all-values.yaml
+++ b/charts/generic/ci/all-values.yaml
@@ -57,7 +57,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
-      paths: []
+      paths: [/]
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/generic/ci/simple-values.yaml
+++ b/charts/generic/ci/simple-values.yaml
@@ -1,0 +1,2 @@
+ingress:
+  enabled: true

--- a/charts/generic/templates/ingress.yaml
+++ b/charts/generic/templates/ingress.yaml
@@ -44,6 +44,9 @@ spec:
           {{- range .paths }}
           - {{- if kindIs "string" . }}
             path: {{ . }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: ImplementationSpecific
+            {{- end }}
             {{- else }}
             path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}

--- a/charts/generic/templates/ingress.yaml
+++ b/charts/generic/templates/ingress.yaml
@@ -42,9 +42,13 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - {{- if kindIs "string" . }}
+            path: {{ . }}
+            {{- else }}
+            path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
+            {{- end }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}

--- a/charts/generic/templates/ingress.yaml
+++ b/charts/generic/templates/ingress.yaml
@@ -1,7 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "generic.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -16,6 +23,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -32,10 +42,20 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -60,12 +60,15 @@ service:
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
-      paths: []
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/postgrest/Chart.yaml
+++ b/charts/postgrest/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgrest
 description: A Helm chart for deploying Postgrest to Kubernetes
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: v8.0.0
 icon: https://avatars.githubusercontent.com/u/15115011?s=200&v=4
 maintainers:

--- a/charts/postgrest/NEWS.md
+++ b/charts/postgrest/NEWS.md
@@ -1,3 +1,7 @@
+# 0.3.2
+
+- Update ingress to use newer template, api version, etc.
+
 # 0.3.1
 
 - Add `extraObjects` value for deploying other kubernetes objects.

--- a/charts/postgrest/README.md
+++ b/charts/postgrest/README.md
@@ -1,14 +1,14 @@
 # postgrest
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v8.0.0](https://img.shields.io/badge/AppVersion-v8.0.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v8.0.0](https://img.shields.io/badge/AppVersion-v8.0.0-informational?style=flat-square)
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.3.1:
+To install the chart with the release name `my-release` at version 0.3.2:
 
 ```bash
 helm repo add colearendt https://colearendt.github.io/helm
-helm install my-release colearendt/postgrest --version=0.3.1
+helm install my-release colearendt/postgrest --version=0.3.2
 ```
 
 #### _A Helm chart for deploying Postgrest to Kubernetes_
@@ -31,9 +31,11 @@ helm install my-release colearendt/postgrest --version=0.3.1
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | object | `{}` |  |
 | nameOverride | string | `""` |  |

--- a/charts/postgrest/ci/complex-values.yaml
+++ b/charts/postgrest/ci/complex-values.yaml
@@ -1,3 +1,11 @@
+ingress:
+  enabled: true
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: [/]
 extraObjects:
   - apiVersion: v1
     kind: ConfigMap

--- a/charts/postgrest/ci/complex-values.yaml
+++ b/charts/postgrest/ci/complex-values.yaml
@@ -6,6 +6,8 @@ ingress:
   hosts:
     - host: chart-example.local
       paths: [/]
+postgrest:
+  dbAnonRole: someRole
 extraObjects:
   - apiVersion: v1
     kind: ConfigMap

--- a/charts/postgrest/ci/empty-values.yaml
+++ b/charts/postgrest/ci/empty-values.yaml
@@ -1,0 +1,2 @@
+postgrest:
+  dbAnonRole: someRole

--- a/charts/postgrest/ci/simple-values.yaml
+++ b/charts/postgrest/ci/simple-values.yaml
@@ -5,3 +5,5 @@ pod:
   env:
     - name: TEST
       value: TEST
+ingress:
+  enabled: true

--- a/charts/postgrest/ci/simple-values.yaml
+++ b/charts/postgrest/ci/simple-values.yaml
@@ -1,6 +1,7 @@
 postgrest:
   dbUri: some-secret
   jwtSecret: another-secret
+  dbAnonRole: someRole
 pod:
   env:
     - name: TEST

--- a/charts/postgrest/templates/deployment.yaml
+++ b/charts/postgrest/templates/deployment.yaml
@@ -135,12 +135,18 @@ spec:
             - name: http
               containerPort: {{ .Values.pod.containerPort }}
               protocol: TCP
+          {{- with .Values.pod.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.pod.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.pod.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.pod.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.pod.startupProbe }}
           startupProbe:
-            {{- toYaml .Values.pod.startupProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/postgrest/templates/ingress.yaml
+++ b/charts/postgrest/templates/ingress.yaml
@@ -44,6 +44,9 @@ spec:
           {{- range .paths }}
           - {{- if kindIs "string" . }}
             path: {{ . }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: ImplementationSpecific
+            {{- end }}
             {{- else }}
             path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}

--- a/charts/postgrest/templates/ingress.yaml
+++ b/charts/postgrest/templates/ingress.yaml
@@ -1,7 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "postgrest.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -16,6 +23,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -32,10 +42,20 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/postgrest/templates/ingress.yaml
+++ b/charts/postgrest/templates/ingress.yaml
@@ -42,9 +42,13 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - {{- if kindIs "string" . }}
+            path: {{ . }}
+            {{- else }}
+            path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
+            {{- end }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}

--- a/charts/postgrest/values.yaml
+++ b/charts/postgrest/values.yaml
@@ -93,12 +93,15 @@ service:
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
-      paths: []
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/traefik-forward-auth/Chart.yaml
+++ b/charts/traefik-forward-auth/Chart.yaml
@@ -1,6 +1,6 @@
 name: traefik-forward-auth
 description: Deploy traefik-forward-auth
-version: 0.0.8
+version: 0.0.9
 apiVersion: v1
 sources:
   - https://github.com/thomseddon/traefik-forward-auth

--- a/charts/traefik-forward-auth/NEWS.md
+++ b/charts/traefik-forward-auth/NEWS.md
@@ -1,3 +1,7 @@
+# 0.0.9
+
+- Update ingress to use newer template, api version, etc.
+
 # 0.0.8
 
 - Add `ingress` values to more easily deploy an ingress object

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -1,14 +1,14 @@
 # traefik-forward-auth
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square)
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.0.8:
+To install the chart with the release name `my-release` at version 0.0.9:
 
 ```bash
 helm repo add colearendt https://colearendt.github.io/helm
-helm install my-release colearendt/traefik-forward-auth --version=0.0.8
+helm install my-release colearendt/traefik-forward-auth --version=0.0.9
 ```
 
 #### _Deploy traefik-forward-auth_
@@ -28,9 +28,11 @@ helm install my-release colearendt/traefik-forward-auth --version=0.0.8
 | image.repository | string | `"thomseddon/traefik-forward-auth"` |  |
 | image.tag | int | `2` |  |
 | ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths[0] | string | `"/"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | livenessProbe | object | `{}` |  |
 | nameOverride | string | `""` |  |

--- a/charts/traefik-forward-auth/ci/all-values.yaml
+++ b/charts/traefik-forward-auth/ci/all-values.yaml
@@ -1,7 +1,7 @@
 config:
   log-level: warn
   default-provider: oidc
-  providers.oidc.issuer-url: http://some-url.example.com
+  providers.oidc.issuer-url: https://demo.okta.com
   providers.oidc.client-id: auth
   providers.oidc.client-secret: super-secret
   insecure-cookie: false

--- a/charts/traefik-forward-auth/ci/empty-values.yaml
+++ b/charts/traefik-forward-auth/ci/empty-values.yaml
@@ -1,0 +1,5 @@
+config:
+  secret: something-secret
+  providers.oidc.issuer-url: https://demo.okta.com
+  providers.oidc.client-id: auth
+  providers.oidc.client-secret: super-secret

--- a/charts/traefik-forward-auth/ci/simple-values.yaml
+++ b/charts/traefik-forward-auth/ci/simple-values.yaml
@@ -1,2 +1,7 @@
 ingress:
   enabled: true
+config:
+  secret: secrety-secret
+  providers.oidc.issuer-url: https://demo.okta.com
+  providers.oidc.client-id: auth
+  providers.oidc.client-secret: super-secret

--- a/charts/traefik-forward-auth/ci/simple-values.yaml
+++ b/charts/traefik-forward-auth/ci/simple-values.yaml
@@ -1,0 +1,2 @@
+ingress:
+  enabled: true

--- a/charts/traefik-forward-auth/templates/ingress.yaml
+++ b/charts/traefik-forward-auth/templates/ingress.yaml
@@ -44,10 +44,13 @@ spec:
           {{- range .paths }}
           - {{- if kindIs "string" . }}
             path: {{ . }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: ImplementationSpecific
+            {{- end }}
             {{- else }}
             path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             {{- end }}
             {{- end }}
             backend:

--- a/charts/traefik-forward-auth/templates/ingress.yaml
+++ b/charts/traefik-forward-auth/templates/ingress.yaml
@@ -42,9 +42,13 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - {{- if kindIs "string" . }}
+            path: {{ . }}
+            {{- else }}
+            path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
+            {{- end }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}

--- a/charts/traefik-forward-auth/templates/ingress.yaml
+++ b/charts/traefik-forward-auth/templates/ingress.yaml
@@ -1,8 +1,14 @@
 {{- if .Values.ingress.enabled -}}
-{{- /* $fullName := include "traefik-forward-auth.fullname" . */ -}}
-{{- $fullName := $.Release.Name -}}
+{{- $fullName := include "traefik-forward-auth.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -17,6 +23,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -33,10 +42,20 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/traefik-forward-auth/values.yaml
+++ b/charts/traefik-forward-auth/values.yaml
@@ -35,12 +35,15 @@ readinessProbe: {}
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
-      paths: [/]
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
close #39 
close #30 

switch to using the new ingress template that supports newer Kubernetes versions (with some nice backwards compatibility TBH). Also modified to ensure that the chart itself is backwards compatible.

Worth noting that the new spec should look like:
```
ingress:
  enabled: false
  className: ""
  annotations: {}
    # kubernetes.io/ingress.class: nginx
    # kubernetes.io/tls-acme: "true"
  hosts:
    - host: chart-example.local
      paths:
        - path: /
          pathType: ImplementationSpecific
```

Instead of the old:
```
ingress:
  enabled: false
  annotations: {}
    # kubernetes.io/ingress.class: nginx
    # kubernetes.io/tls-acme: "true"
  hosts:
    - host: chart-example.local
      paths: [/]
```

For backwards compatibility, also added CI to support the older pattern along with newer.