### PR TITLE
make the required values mandatory in postgrest

### DIFF
--- a/charts/regcred/templates/secret.yaml
+++ b/charts/regcred/templates/secret.yaml
@@ -1,14 +1,13 @@
-{{- if .Values.registryCredentials -}}
-kind: Secret
-type: kubernetes.io/dockerconfigjson
 apiVersion: v1
+kind: Secret
 metadata:
-  name: {{ include "regcred.fullname" . }}
-  labels:
-    {{- include "regcred.labels" . | nindent 4}}
-    {{- with .Values.extraLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-data:
-  .dockerconfigjson: {{- include "regcred.registryCredentials" .Values.registryCredentials | nindent 4 }}
-{{- end -}}
+  name: {{ include "postgrest.fullname" . }}-secret
+  namespace: {{ $.Release.Namespace }}
+stringData:
+  db-uri.txt: |-
+    {{- required "Missing postgrest.dbUri" .Values.postgrest.dbUri | nindent 4 }}
+  jwt-secret.txt: |-
+    {{- required "postgrest.jwtSecret" .Values.postgrest.jwtSecret | nindent 4 }}
+  {{- if .Values.secret }}
+    {{- toYaml .Values.secret | nindent 2 }}
+  {{- end }}


### PR DESCRIPTION
The values
- postgrest.dbUri
- postgrest.jwtSecret

are required to make a working deployment. To reflect that I have made the to parameters mandatory in the template