### PR TITLE
Enable admin port

### DIFF
--- a/charts/postgrest/templates/_helpers.tpl
+++ b/charts/postgrest/templates/_helpers.tpl
@@ -75,3 +75,11 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Set the value of PGRST_ADMIN_SERVER_PORT to a fixed port.
+*/}}
+{{- define "postgrest.adminPort" -}}
+9001
+{{- end }}
+

--- a/charts/postgrest/templates/deployment.yaml
+++ b/charts/postgrest/templates/deployment.yaml
@@ -128,6 +128,10 @@ spec:
             - name: PGRST_RAW_MEDIA_TYPES
               value: {{ .Values.postgrest.rawMediaTypes }}
             {{- end }}
+            {{- if .Values.postgrest.adminServerPort }}
+            - name: PGRST_ADMIN_SERVER_PORT
+              value: {{ include "postgrest.adminPort" . }}
+            {{- end }}
             {{- if .Values.pod.env }}
               {{- toYaml .Values.pod.env | nindent 12 }}
             {{- end }}
@@ -135,10 +139,15 @@ spec:
             - name: http
               containerPort: {{ .Values.pod.containerPort }}
               protocol: TCP
-          {{- with .Values.pod.readinessProbe }}
+            - name: http-admin
+              containerPort: {{ include "postgrest.adminPort" . }}
+              protocol: TCP
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            httpGet:
+              path: /
+              port: http-admin
+            initialDelaySeconds: 5
+            periodSeconds: 5
           {{- with .Values.pod.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/postgrest/templates/deployment.yaml
+++ b/charts/postgrest/templates/deployment.yaml
@@ -128,10 +128,8 @@ spec:
             - name: PGRST_RAW_MEDIA_TYPES
               value: {{ .Values.postgrest.rawMediaTypes }}
             {{- end }}
-            {{- if .Values.postgrest.adminServerPort }}
             - name: PGRST_ADMIN_SERVER_PORT
-              value: {{ include "postgrest.adminPort" . }}
-            {{- end }}
+              value: {{ include "postgrest.adminPort" . | quote }}
             {{- if .Values.pod.env }}
               {{- toYaml .Values.pod.env | nindent 12 }}
             {{- end }}
@@ -144,7 +142,7 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /
+              path: /live
               port: http-admin
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/charts/postgrest/templates/service.yaml
+++ b/charts/postgrest/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.postgrest.adminServerPort }}
+    - port: {{ include "postgrest.adminPort" . }}
+      targetPort: http-admin
+      protocol: TCP
+      name: http-admin
+    {{- end }}
   selector:
     {{- include "postgrest.selectorLabels" . | nindent 4 }}

--- a/charts/postgrest/values.yaml
+++ b/charts/postgrest/values.yaml
@@ -75,18 +75,12 @@ pod:
   annotations: {}
   containerPort: 9000
   env: []
-  readinessProbe:
-    httpGet:
-      path: /
-      port: http
-    initialDelaySeconds: 5
-    periodSeconds: 5
   livenessProbe: {}
   startupProbe: {}
   volumes: []
   volumeMounts: []
   securityContext: {}
-
+  
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
I was trying to make a release and discovered that the readiness probe failed because it returned HTTP 401.
In order to address this I have enabled the admin port (see https://postgrest.org/en/stable/references/admin.html#health-check) and set the readiness probe to use that port (`/live`).
I have disabled the possibility to set a custom readinessprobe - not sure if this should stay like this or if it should be optional