### PR TITLE
create pod.env field when values are present

### DIFF
--- a/charts/traefik-forward-auth/Chart.yaml
+++ b/charts/traefik-forward-auth/Chart.yaml
@@ -1,6 +1,6 @@
 name: traefik-forward-auth
 description: Deploy traefik-forward-auth
-version: 0.0.10
+version: 0.0.11
 apiVersion: v1
 sources:
   - https://github.com/thomseddon/traefik-forward-auth

--- a/charts/traefik-forward-auth/NEWS.md
+++ b/charts/traefik-forward-auth/NEWS.md
@@ -1,3 +1,7 @@
+# 0.0.11
+
+- Set pod.env field when env vars are provided
+
 # 0.0.10
 
 - Add tolerations, nodeSelector, and affinity values

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -1,14 +1,14 @@
 # traefik-forward-auth
 
-![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square)
+![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square)
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.0.10:
+To install the chart with the release name `my-release` at version 0.0.11:
 
 ```bash
 helm repo add colearendt https://colearendt.github.io/helm
-helm install my-release colearendt/traefik-forward-auth --version=0.0.10
+helm install my-release colearendt/traefik-forward-auth --version=0.0.11
 ```
 
 #### _Deploy traefik-forward-auth_

--- a/charts/traefik-forward-auth/templates/pod.yaml
+++ b/charts/traefik-forward-auth/templates/pod.yaml
@@ -25,7 +25,8 @@ spec:
       - name: proxy
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         {{- if .Values.pod.env }}
-{{ toYaml .Values.pod.env | indent 8 }}
+        env:
+{{ toYaml .Values.pod.env | indent 10 }}
         {{- end }}
         {{- if .Values.command }}
         command:


### PR DESCRIPTION
Ensures that `pod.env` variables are nested under a `env` field. Allows consumers to do something like 
```
pod:
  env:
    - name: MY_ENV_VAR
      valueFrom:
        secretKeyRef:
          name: my-secret
          key: my-secret-key
```

in their `values.yaml`