### PR TITLE
Traefik auth pod env

### DIFF
--- a/charts/traefik-forward-auth/Chart.yaml
+++ b/charts/traefik-forward-auth/Chart.yaml
@@ -1,6 +1,6 @@
 name: traefik-forward-auth
 description: Deploy traefik-forward-auth
-version: 0.0.11
+version: 0.0.12
 apiVersion: v1
 sources:
   - https://github.com/thomseddon/traefik-forward-auth

--- a/charts/traefik-forward-auth/NEWS.md
+++ b/charts/traefik-forward-auth/NEWS.md
@@ -1,3 +1,7 @@
+# 0.0.12
+
+- Switch pod.env field to a list
+
 # 0.0.11
 
 - Set pod.env field when env vars are provided

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -1,14 +1,14 @@
 # traefik-forward-auth
 
-![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square)
+![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square)
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.0.11:
+To install the chart with the release name `my-release` at version 0.0.12:
 
 ```bash
 helm repo add colearendt https://colearendt.github.io/helm
-helm install my-release colearendt/traefik-forward-auth --version=0.0.11
+helm install my-release colearendt/traefik-forward-auth --version=0.0.12
 ```
 
 #### _Deploy traefik-forward-auth_
@@ -38,7 +38,7 @@ helm install my-release colearendt/traefik-forward-auth --version=0.0.11
 | livenessProbe | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
-| pod.env | object | `{}` |  |
+| pod.env | list | `[]` |  |
 | podAnnotations | object | `{}` |  |
 | readinessProbe | object | `{}` |  |
 | replicas | int | `1` |  |

--- a/charts/traefik-forward-auth/values.yaml
+++ b/charts/traefik-forward-auth/values.yaml
@@ -29,7 +29,7 @@ affinity: {}
 extraObjects: []
 
 pod:
-  env: {}
+  env: []
 command:
   - './traefik-forward-auth'
 args:


### PR DESCRIPTION
Switch the pod env to a list to prevent the following error when trying to set a list of env vars for `pod.env`:
```
warning: cannot overwrite table with non table for traefik-forward-auth.pod.env (map[])
```