### PR TITLE
Traefik Forward Auth - Volumes and Service Account

### DIFF
--- a/charts/traefik-forward-auth/Chart.yaml
+++ b/charts/traefik-forward-auth/Chart.yaml
@@ -1,6 +1,6 @@
 name: traefik-forward-auth
 description: Deploy traefik-forward-auth
-version: 0.0.12
+version: 0.0.13
 apiVersion: v1
 sources:
   - https://github.com/thomseddon/traefik-forward-auth

--- a/charts/traefik-forward-auth/NEWS.md
+++ b/charts/traefik-forward-auth/NEWS.md
@@ -1,3 +1,7 @@
+# 0.0.13
+
+- Add pod volumes and volume mounts and option to create a service account
+
 # 0.0.12
 
 - Switch pod.env field to a list

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -1,14 +1,14 @@
 # traefik-forward-auth
 
-![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square)
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.0.12:
+To install the chart with the release name `my-release` at version 0.0.13:
 
 ```bash
 helm repo add colearendt https://colearendt.github.io/helm
-helm install my-release colearendt/traefik-forward-auth --version=0.0.12
+helm install my-release colearendt/traefik-forward-auth --version=0.0.13
 ```
 
 #### _Deploy traefik-forward-auth_
@@ -39,11 +39,16 @@ helm install my-release colearendt/traefik-forward-auth --version=0.0.12
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | pod.env | list | `[]` |  |
+| pod.volumeMounts | list | `[]` |  |
+| pod.volumes | list | `[]` |  |
 | podAnnotations | object | `{}` |  |
 | readinessProbe | object | `{}` |  |
 | replicas | int | `1` |  |
 | resources | object | `{}` |  |
 | service.port | int | `80` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. -- If not set and create is true, a name is generated using the fullname template |
 | serviceAnnotations | object | `{}` |  |
 | startupProbe | object | `{}` |  |
 | strategy | object | `{}` |  |

--- a/charts/traefik-forward-auth/templates/_helpers.tpl
+++ b/charts/traefik-forward-auth/templates/_helpers.tpl
@@ -50,3 +50,14 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "traefik-forward-auth.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "traefik-forward-auth.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/traefik-forward-auth/templates/pod.yaml
+++ b/charts/traefik-forward-auth/templates/pod.yaml
@@ -42,6 +42,9 @@ spec:
         volumeMounts:
           - name: config
             mountPath: "/config"
+          {{- if .Values.pod.volumeMounts }}
+{{ toYaml .Values.pod.volumeMounts | indent 10 }}
+          {{- end }}
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -77,4 +80,7 @@ spec:
           items:
           - key: config.ini
             path: "config.ini"
+      {{- if .Values.pod.volumes }}
+{{ toYaml .Values.pod.volumes | indent 6 }}
+      {{- end }}
 ---

--- a/charts/traefik-forward-auth/templates/serviceaccount.yaml
+++ b/charts/traefik-forward-auth/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "traefik-forward-auth.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/traefik-forward-auth/values.yaml
+++ b/charts/traefik-forward-auth/values.yaml
@@ -30,6 +30,9 @@ extraObjects: []
 
 pod:
   env: []
+  volumes: []
+  volumeMounts: []
+
 command:
   - './traefik-forward-auth'
 args:
@@ -54,3 +57,12 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: false
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # -- If not set and create is true, a name is generated using the fullname template
+  name: ""


### PR DESCRIPTION
### Traefik Forward Auth Chart
- Add an option to create an annotated service account (defaults to `false`)
- Add the ability to give additional volumes and volume mounts to the pod