### PR TITLE
set serviceAccountName on auth deployment

### DIFF
--- a/charts/traefik-forward-auth/Chart.yaml
+++ b/charts/traefik-forward-auth/Chart.yaml
@@ -1,6 +1,6 @@
 name: traefik-forward-auth
 description: Deploy traefik-forward-auth
-version: 0.0.13
+version: 0.0.14
 apiVersion: v1
 sources:
   - https://github.com/thomseddon/traefik-forward-auth

--- a/charts/traefik-forward-auth/NEWS.md
+++ b/charts/traefik-forward-auth/NEWS.md
@@ -1,3 +1,7 @@
+# 0.0.14
+
+- Set serviceAccountName on deployment
+
 # 0.0.13
 
 - Add pod volumes and volume mounts and option to create a service account

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -1,14 +1,14 @@
 # traefik-forward-auth
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square)
+![Version: 0.0.14](https://img.shields.io/badge/Version-0.0.14-informational?style=flat-square)
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release` at version 0.0.13:
+To install the chart with the release name `my-release` at version 0.0.14:
 
 ```bash
 helm repo add colearendt https://colearendt.github.io/helm
-helm install my-release colearendt/traefik-forward-auth --version=0.0.13
+helm install my-release colearendt/traefik-forward-auth --version=0.0.14
 ```
 
 #### _Deploy traefik-forward-auth_

--- a/charts/traefik-forward-auth/templates/pod.yaml
+++ b/charts/traefik-forward-auth/templates/pod.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ include "traefik-forward-auth.serviceAccountName" . }}
       containers:
       - name: proxy
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
So that the pod runs under the desired service account. Resolves to `default` when `serviceAccount.create == false`