### PR TITLE
update variable name

### DIFF
--- a/charts/postgrest/templates/deployment.yaml
+++ b/charts/postgrest/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
               value: "@/mnt/secret/jwt-secret.txt"
             {{- end }}
             {{- if .Values.postgrest.secretIsBase64 }}
-            - name: PGRST_SECRET_IS_BASE64
+            - name: PGRST_JWT_SECRET_IS_BASE64
               value: {{ .Values.postgrest.secretIsBase64 }}
             {{- end }}
             {{- if .Values.postgrest.jwtAud }}


### PR DESCRIPTION
According to the [latest documentation](https://postgrest.org/en/stable/references/configuration.html#jwt-secret-is-base64) this variable name should be PGRST_JWT_SECRET_IS_BASE64
