### PR TITLE
Force value to be a string

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0

--- a/charts/postgrest/templates/deployment.yaml
+++ b/charts/postgrest/templates/deployment.yaml
@@ -114,7 +114,7 @@ spec:
             {{- end }}
             {{- if .Values.postgrest.maxRows }}
             - name: PGRST_DB_MAX_ROWS
-              value: {{ .Values.postgrest.maxRows }}
+              value: !!str {{ .Values.postgrest.maxRows }}
             {{- end }}
             {{- if .Values.postgrest.preRequest }}
             - name: PGRST_PRE_REQUEST


### PR DESCRIPTION
It started failing in my deployment:
```
Error: UPGRADE FAILED: failed to create resource: Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```